### PR TITLE
Streaming API

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,16 @@ goos: linux
 goarch: amd64
 pkg: byrd-bench
 cpu: AMD EPYC 7763 64-Core Processor                
-BenchmarkDecode/byrd/440hz-2                   1        1386793842 ns/op           0.58 MB/s    140145296 B/op      7535 allocs/op
-BenchmarkDecode/go-mp3/440hz-2                 1        1895197625 ns/op           0.42 MB/s    401718176 B/op    832089 allocs/op
-BenchmarkDecode/byrd/alarm-2                   2         557039262 ns/op           1.32 MB/s    46667136 B/op       2912 allocs/op
-BenchmarkDecode/go-mp3/alarm-2                 2         676362464 ns/op           1.08 MB/s    107437632 B/op    225285 allocs/op
-BenchmarkDecode/byrd/song-2                    1        2168383865 ns/op           1.91 MB/s    145648976 B/op      9967 allocs/op
-BenchmarkDecode/go-mp3/song-2                  1        2297369434 ns/op           1.80 MB/s    337330800 B/op    693343 allocs/op
-BenchmarkDecode/byrd/synth-2                   5         269016935 ns/op           1.14 MB/s    18706784 B/op       1164 allocs/op
-BenchmarkDecode/go-mp3/synth-2                 4         322580975 ns/op           0.95 MB/s    48806280 B/op     102876 allocs/op
-BenchmarkDecode/byrd/circle-reading-2                  1        77254737684 ns/op          1.10 MB/s    6377618904 B/op   392294 allocs/op
-BenchmarkDecode/go-mp3/circle-reading-2                1        89520887751 ns/op          0.95 MB/s    14913806568 B/op        31594022 allocs/op
+BenchmarkDecode/byrd/440hz-2                   1        1414838350 ns/op           0.56 MB/s    73397944 B/op   13512 allocs/op
+BenchmarkDecode/go-mp3/440hz-2                 1        1789270359 ns/op           0.45 MB/s    401718432 B/op  832091 allocs/op
+BenchmarkDecode/byrd/alarm-2                   2         563254048 ns/op           1.30 MB/s    17954744 B/op    4525 allocs/op
+BenchmarkDecode/go-mp3/alarm-2                 2         583913758 ns/op           1.26 MB/s    107437704 B/op  225285 allocs/op
+BenchmarkDecode/byrd/song-2                    1        2236068400 ns/op           1.85 MB/s    59609384 B/op   14919 allocs/op
+BenchmarkDecode/go-mp3/song-2                  1        2495641055 ns/op           1.66 MB/s    337330784 B/op  693343 allocs/op
+BenchmarkDecode/byrd/synth-2                   5         239184430 ns/op           1.29 MB/s     7939640 B/op    1904 allocs/op
+BenchmarkDecode/go-mp3/synth-2                 4         265875043 ns/op           1.16 MB/s    48806272 B/op  102876 allocs/op
+BenchmarkDecode/byrd/circle-reading-2                  1        83411402901 ns/op          1.02 MB/s    2376424176 B/op         618368 allocs/op
+BenchmarkDecode/go-mp3/circle-reading-2                1        82844266854 ns/op          1.03 MB/s    14913806760 B/op      31594024 allocs/op
 ```
 
-In comparison to hajimehoshi/go-mp3, allocs/op for Byrd is very few for all sample files. It's also faster looking at the ns/op and throughput
+Byrd decodes mp3 with lower allocation bytes per op

--- a/README.md
+++ b/README.md
@@ -23,12 +23,23 @@ if err != nil {
 	log.Fatal(err)
 }
 
-pcm, err := dec.Decode()
+pcm, err := io.ReadAll(dec)
 if err != nil {
 	log.Fatal(err)
 }
 
-if err := pcm.WriteWAVFile("output.wav"); err != nil {
+log.Printf("decoded %d PCM bytes at %d Hz with %d channels", len(pcm), dec.SampleRate(), dec.Channels())
+```
+
+Decode MP3 file at once (non-streaming use cases)
+
+```go
+pcmData, err := dec.BatchDecode()
+if err != nil {
+	log.Fatal(err)
+}
+
+if err := pcmData.WriteWAVFile("output.wav"); err != nil {
 	log.Fatal(err)
 }
 ```
@@ -42,16 +53,16 @@ goos: darwin
 goarch: arm64
 pkg: byrd-bench
 cpu: Apple M2
-BenchmarkDecode/byrd/440hz-8                   2         772611416 ns/op           1.03 MB/s    140150616 B/op      7541 allocs/op
-BenchmarkDecode/go-mp3/440hz-8                 1        1162266375 ns/op           0.69 MB/s    401718448 B/op    832091 allocs/op
-BenchmarkDecode/byrd/alarm-8                   4         299168010 ns/op           2.45 MB/s    46667164 B/op       2912 allocs/op
-BenchmarkDecode/go-mp3/alarm-8                 3         372317639 ns/op           1.97 MB/s    107437728 B/op    225285 allocs/op
-BenchmarkDecode/byrd/song-8                    1        1205008584 ns/op           3.44 MB/s    145648976 B/op      9967 allocs/op
-BenchmarkDecode/go-mp3/song-8                  1        1365143459 ns/op           3.04 MB/s    337331008 B/op    693346 allocs/op
-BenchmarkDecode/byrd/synth-8                   8         136862448 ns/op           2.25 MB/s    18706784 B/op       1164 allocs/op
-BenchmarkDecode/go-mp3/synth-8                 7         167811369 ns/op           1.83 MB/s    48806390 B/op     102876 allocs/op
-BenchmarkDecode/byrd/circle-reading-8                  1        41794333000 ns/op          2.03 MB/s    6377618920 B/op   392295 allocs/op
-BenchmarkDecode/go-mp3/circle-reading-8                1        50479988500 ns/op          1.68 MB/s    14913809400 B/op        31594042 allocs/op
+BenchmarkDecode/byrd/440hz-8                   2         761768375 ns/op           1.05 MB/s    73397840 B/op      13511 allocs/op
+BenchmarkDecode/go-mp3/440hz-8                 1        1122291417 ns/op           0.71 MB/s    401718416 B/op    832092 allocs/op
+BenchmarkDecode/byrd/alarm-8                   4         301212552 ns/op           2.44 MB/s    17954744 B/op       4525 allocs/op
+BenchmarkDecode/go-mp3/alarm-8                 3         372493167 ns/op           1.97 MB/s    107437600 B/op    225284 allocs/op
+BenchmarkDecode/byrd/song-8                    1        1211818375 ns/op           3.42 MB/s    59609496 B/op      14920 allocs/op
+BenchmarkDecode/go-mp3/song-8                  1        1326870209 ns/op           3.12 MB/s    337331008 B/op    693346 allocs/op
+BenchmarkDecode/byrd/synth-8                   8         136756088 ns/op           2.25 MB/s     7939654 B/op       1904 allocs/op
+BenchmarkDecode/go-mp3/synth-8                 7         166037327 ns/op           1.85 MB/s    48806340 B/op     102876 allocs/op
+BenchmarkDecode/byrd/circle-reading-8                  1        41701810375 ns/op          2.04 MB/s    2376429496 B/op   618374 allocs/op
+BenchmarkDecode/go-mp3/circle-reading-8                1        50237129917 ns/op          1.69 MB/s    14913808680 B/op        31594036 allocs/op
 ```
 
 ```

--- a/api.go
+++ b/api.go
@@ -92,21 +92,38 @@ func (pcm *PCMData) WriteWAVFile(path string) error {
 }
 
 type Decoder struct {
-	r io.Reader
+	r *decoder.Reader
 }
 
 func NewDecoder(r io.Reader) (*Decoder, error) {
-	return &Decoder{r: r}, nil
+	return &Decoder{r: decoder.NewReader(bufio.NewReader(r))}, nil
 }
 
-func (d *Decoder) Decode() (*PCMData, error) {
-	samples, sampleRate, channels, err := decoder.DecodeMP3Frames(bufio.NewReader(d.r))
+func (d *Decoder) Read(p []byte) (int, error) {
+	return d.r.Read(p)
+}
+
+func (d *Decoder) SampleRate() uint16 {
+	return d.r.SampleRate()
+}
+
+func (d *Decoder) Channels() int {
+	return d.r.Channels()
+}
+
+func (d *Decoder) BatchDecode() (*PCMData, error) {
+	raw, err := io.ReadAll(d)
 	if err != nil {
 		return nil, err
 	}
+	samples := make([]int16, len(raw)/2)
+	for i := range samples {
+		j := i * 2
+		samples[i] = int16(uint16(raw[j]) | uint16(raw[j+1])<<8)
+	}
 	return &PCMData{
 		Samples:    samples,
-		SampleRate: sampleRate,
-		Channels:   channels,
+		SampleRate: d.SampleRate(),
+		Channels:   d.Channels(),
 	}, nil
 }

--- a/api_test.go
+++ b/api_test.go
@@ -2,12 +2,15 @@ package byrd
 
 import (
 	"encoding/binary"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 )
+
+var _ io.Reader = (*Decoder)(nil)
 
 func mustListStaticMP3Paths(t *testing.T) []string {
 	t.Helper()
@@ -37,11 +40,32 @@ func mustDecodePath(t *testing.T, path string) *PCMData {
 		t.Fatalf("NewDecoder failed: %v", err)
 	}
 
-	pcm, err := dec.Decode()
+	pcm, err := dec.BatchDecode()
 	if err != nil {
 		t.Fatalf("Decode failed: %v", err)
 	}
 	return pcm
+}
+
+func mustReadPath(t *testing.T, path string) ([]byte, uint16, int) {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open mp3: %v", err)
+	}
+	defer f.Close()
+
+	dec, err := NewDecoder(f)
+	if err != nil {
+		t.Fatalf("NewDecoder failed: %v", err)
+	}
+
+	raw, err := io.ReadAll(dec)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	return raw, dec.SampleRate(), dec.Channels()
 }
 
 func TestDecoder_Decode(t *testing.T) {
@@ -62,6 +86,88 @@ func TestDecoder_Decode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecoder_Read(t *testing.T) {
+	for _, path := range mustListStaticMP3Paths(t) {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			raw, sampleRate, channels := mustReadPath(t, path)
+			if sampleRate == 0 {
+				t.Fatalf("sample rate must be non-zero")
+			}
+			if channels <= 0 {
+				t.Fatalf("channels must be positive")
+			}
+			if len(raw) == 0 {
+				t.Fatalf("raw PCM must be non-empty")
+			}
+			if len(raw)%2 != 0 {
+				t.Fatalf("raw PCM byte count must be even: %d", len(raw))
+			}
+		})
+	}
+}
+
+func TestDecoder_ReadMatchesDecode(t *testing.T) {
+	for _, path := range mustListStaticMP3Paths(t) {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			pcm := mustDecodePath(t, path)
+			raw, sampleRate, channels := mustReadPath(t, path)
+
+			if sampleRate != pcm.SampleRate {
+				t.Fatalf("sample rate mismatch: read=%d decode=%d", sampleRate, pcm.SampleRate)
+			}
+			if channels != pcm.Channels {
+				t.Fatalf("channel mismatch: read=%d decode=%d", channels, pcm.Channels)
+			}
+			if len(raw) != len(pcm.Samples)*2 {
+				t.Fatalf("sample byte mismatch: read=%d decode=%d", len(raw), len(pcm.Samples)*2)
+			}
+			for i, want := range pcm.Samples {
+				j := i * 2
+				got := int16(uint16(raw[j]) | uint16(raw[j+1])<<8)
+				if got != want {
+					t.Fatalf("sample %d mismatch: read=%d decode=%d", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDecoder_ReadSmallOddBuffer(t *testing.T) {
+	path := filepath.Join("static", "synth.mp3")
+	t.Run(filepath.Base(path), func(t *testing.T) {
+		want, _, _ := mustReadPath(t, path)
+
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("failed to open mp3: %v", err)
+		}
+		defer f.Close()
+
+		dec, err := NewDecoder(f)
+		if err != nil {
+			t.Fatalf("NewDecoder failed: %v", err)
+		}
+
+		buf := make([]byte, 3)
+		var got []byte
+		for {
+			n, err := dec.Read(buf)
+			if n > 0 {
+				got = append(got, buf[:n]...)
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("Read failed: %v", err)
+			}
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("small-buffer read mismatch: got %d bytes want %d", len(got), len(want))
+		}
+	})
 }
 
 func TestPCMData_WriteWAVFile(t *testing.T) {

--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -95,13 +95,14 @@ func decodeWithByrd(path string) (decodeResult, error) {
 		return decodeResult{}, err
 	}
 
-	pcm, err := dec.Decode()
+	raw, err := io.ReadAll(dec)
 	if err != nil {
 		return decodeResult{}, err
 	}
+	sampleCount := len(raw) / 2
 	return decodeResult{
-		decodedBytes: len(pcm.Samples) * 2,
-		samples:      len(pcm.Samples),
+		decodedBytes: len(raw),
+		samples:      sampleCount,
 	}, nil
 }
 

--- a/example/stream_pcm/main.go
+++ b/example/stream_pcm/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -24,12 +25,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	pcm, err := dec.Decode()
+	raw, err := io.ReadAll(dec)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("sample_rate=%d\n", pcm.SampleRate)
-	fmt.Printf("channels=%d\n", pcm.Channels)
-	fmt.Printf("samples=%d\n", len(pcm.Samples))
+	fmt.Printf("sample_rate=%d\n", dec.SampleRate())
+	fmt.Printf("channels=%d\n", dec.Channels())
+	fmt.Printf("bytes=%d\n", len(raw))
 }

--- a/example/to_wav/main.go
+++ b/example/to_wav/main.go
@@ -23,7 +23,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	pcm, err := dec.Decode()
+	pcm, err := dec.BatchDecode()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -27,162 +27,224 @@ func OpenMP3File(path string) (io.ReadCloser, error) {
 	return os.Open(path)
 }
 
-func DecodeMP3Frames(r *bufio.Reader) ([]int16, uint16, int, error) {
-	var h header.MP3FrameHeader
-	var mainDataReservoir []byte
-	var sideInfoBuf []byte
-	var cur []byte
-	var mainData []byte
-	var scalefactors [2][2]maindata.Scalefactors
-	var count1 [2][2]int
-	var spectralValues [2][2][576]int
-	var requantizedValues [2][2][576]float32
-	var reorderedValues [2][2][576]float32
-	var hybridValues [2][2][576]float32
-	var overlapState [2][32][18]float32
-	var hybridSamples [2][2][32][18]float32
-	var synthesisState [2]synthesis.PolyphaseState
-	var pcmSamples [2][2][576]float32
-	var out []int16
-	var sampleRate uint16
-	channels := 0
-	for {
-		h = header.MP3FrameHeader{} // reset frame state
-		if err := header.ReadHeader(&h, r); err != nil {
+type Reader struct {
+	r *bufio.Reader
+
+	mainDataReservoir []byte
+	sideInfoBuf       []byte
+	cur               []byte
+	mainData          []byte
+	scalefactors      [2][2]maindata.Scalefactors
+	count1            [2][2]int
+	spectralValues    [2][2][576]int
+	requantizedValues [2][2][576]float32
+	reorderedValues   [2][2][576]float32
+	hybridValues      [2][2][576]float32
+	overlapState      [2][32][18]float32
+	hybridSamples     [2][2][32][18]float32
+	synthesisState    [2]synthesis.PolyphaseState
+	pcmSamples        [2][2][576]float32
+
+	pcm        []byte
+	pcmPos     int
+	sampleRate uint16
+	channels   int
+	eof        bool
+}
+
+func NewReader(r *bufio.Reader) *Reader {
+	return &Reader{r: r}
+}
+
+func (d *Reader) SampleRate() uint16 {
+	return d.sampleRate
+}
+
+func (d *Reader) Channels() int {
+	return d.channels
+}
+
+func (d *Reader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	for d.pcmPos == len(d.pcm) && !d.eof {
+		if err := d.decodeFrame(); err != nil {
 			if err == io.EOF {
+				d.eof = true
 				break
 			}
-			return nil, 0, 0, fmt.Errorf("failed to read MP3 frame header: %w", err)
+			return 0, err
 		}
+	}
+	if d.pcmPos == len(d.pcm) {
+		return 0, io.EOF
+	}
 
-		if !h.ValidateCRC(r) {
-			return nil, 0, 0, fmt.Errorf("CRC check failed for MP3 frame")
-		}
+	n := copy(p, d.pcm[d.pcmPos:])
+	d.pcmPos += n
+	if d.pcmPos == len(d.pcm) {
+		d.pcm = d.pcm[:0]
+		d.pcmPos = 0
+	}
+	return n, nil
+}
 
-		sideInfoLen := header.GetSideInfoLength(&h)
-		if cap(sideInfoBuf) < sideInfoLen {
-			sideInfoBuf = make([]byte, sideInfoLen)
-		}
-		sideInfoBuf = sideInfoBuf[:sideInfoLen]
-		if _, err := io.ReadFull(r, sideInfoBuf); err != nil {
-			return nil, 0, 0, fmt.Errorf("failed to read side info: %w", err)
-		}
-		sideInfo, err := header.ReadSideInfo(&h, sideInfoBuf)
-		if err != nil {
-			return nil, 0, 0, fmt.Errorf("failed to read side info: %w", err)
-		}
+func DecodeMP3Frames(r *bufio.Reader) ([]int16, uint16, int, error) {
+	reader := NewReader(r)
+	raw, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	out := make([]int16, len(raw)/2)
+	for i := range out {
+		j := i * 2
+		out[i] = int16(uint16(raw[j]) | uint16(raw[j+1])<<8)
+	}
+	return out, reader.SampleRate(), reader.Channels(), nil
+}
 
-		frameLen, err := h.GetFrameLength()
-		if err != nil {
-			return nil, 0, 0, fmt.Errorf("failed to calculate frame length: %w", err)
-		}
-		crcLen := 0
-		if h.HasCRC() {
-			crcLen = 2
-		}
+func (d *Reader) decodeFrame() error {
+	var h header.MP3FrameHeader
+	d.pcm = d.pcm[:0]
+	d.pcmPos = 0
 
-		mainDataLen := frameLen - 4 - sideInfoLen - crcLen
-		// we reuse cur buffer for reducing GC overhead, but grow it if needed
-		if cap(cur) < mainDataLen {
-			cur = make([]byte, mainDataLen)
+	h = header.MP3FrameHeader{} // reset frame state
+	if err := header.ReadHeader(&h, d.r); err != nil {
+		if err == io.EOF {
+			return io.EOF
 		}
-		cur = cur[:mainDataLen]
-		_, err = io.ReadFull(r, cur)
-		if err != nil {
-			return nil, 0, 0, fmt.Errorf("failed to read main data: %w", err)
-		}
-		err = maindata.ReadMainData(sideInfo.MainDataBegin, &mainDataReservoir, cur, &mainData)
-		if err != nil {
-			return nil, 0, 0, fmt.Errorf("failed to read main data: %w", err)
-		}
-		br := common.NewBitReader(mainData)
-		frameChannels := 2
-		if h.GetChannelMode() == header.ChannelModeMono {
-			frameChannels = 1
-		}
-		if sampleRate == 0 {
-			sampleRate = h.GetSampleRate()
-			channels = frameChannels
-		} else if sampleRate != h.GetSampleRate() || channels != frameChannels {
-			return nil, 0, 0, fmt.Errorf("variable stream parameters are not supported: sampleRate=%d/%d channels=%d/%d", sampleRate, h.GetSampleRate(), channels, frameChannels)
-		}
-		for gr := range GRANULE_COUNT {
-			for ch := 0; ch < frameChannels; ch++ {
-				gc := &sideInfo.Granule[gr][ch]
-				part23Start := br.Pos
-				part23End := part23Start + int(gc.Part23Length)
+		return fmt.Errorf("failed to read MP3 frame header: %w", err)
+	}
 
-				var prev *maindata.Scalefactors
-				if gr == 1 {
-					prev = &scalefactors[0][ch]
-				}
-				_, err = maindata.ParseScaleFactor(br, gc, sideInfo.SCFSI[ch], gr, prev, &scalefactors[gr][ch])
-				if err != nil {
-					return nil, 0, 0, fmt.Errorf("failed to parse scalefactors: frame granule=%d channel=%d err=%w", gr, ch, err)
-				}
+	if !h.ValidateCRC(d.r) {
+		return fmt.Errorf("CRC check failed for MP3 frame")
+	}
 
-				huffmanLen := part23End - br.Pos
-				if huffmanLen < 0 {
-					return nil, 0, 0, fmt.Errorf("main data underrun: frame granule=%d channel=%d part23=%d bits consumed for scalefactors=%d", gr, ch, gc.Part23Length, br.Pos-part23Start)
-				}
-				spectralBuffer := spectralValues[gr][ch][:]
-				_, err = maindata.ParseBigValues(br, h.GetSampleRate(), gc, part23End, &spectralBuffer)
-				if err != nil {
-					return nil, 0, 0, fmt.Errorf("failed to parse big values: frame granule=%d channel=%d err=%w", gr, ch, err)
-				}
-				count1Lines, err := maindata.ParseCount1Values(br, gc, part23End, &spectralBuffer)
-				if err != nil {
-					return nil, 0, 0, fmt.Errorf("failed to parse count1 values: frame granule=%d channel=%d err=%w", gr, ch, err)
-				}
-				count1[gr][ch] = int(gc.BigValues)*2 + count1Lines
-				requantizedBuffer := requantizedValues[gr][ch][:]
-				if err := maindata.Requantize(h.GetSampleRate(), gc, &scalefactors[gr][ch], spectralBuffer, &requantizedBuffer); err != nil {
-					return nil, 0, 0, fmt.Errorf("failed to requantize values: frame granule=%d channel=%d err=%w", gr, ch, err)
-				}
-				reorderedBuffer := reorderedValues[gr][ch][:]
-				if err := maindata.Reorder(h.GetSampleRate(), gc, requantizedBuffer, &reorderedBuffer); err != nil {
-					return nil, 0, 0, fmt.Errorf("failed to reorder values: frame granule=%d channel=%d err=%w", gr, ch, err)
-				}
-				br.Pos = part23End
-				if br.Pos > len(mainData)*8 {
-					return nil, 0, 0, fmt.Errorf("main data overrun: frame granule=%d channel=%d part23=%d", gr, ch, gc.Part23Length)
-				}
+	sideInfoLen := header.GetSideInfoLength(&h)
+	if cap(d.sideInfoBuf) < sideInfoLen {
+		d.sideInfoBuf = make([]byte, sideInfoLen)
+	}
+	d.sideInfoBuf = d.sideInfoBuf[:sideInfoLen]
+	if _, err := io.ReadFull(d.r, d.sideInfoBuf); err != nil {
+		return fmt.Errorf("failed to read side info: %w", err)
+	}
+	sideInfo, err := header.ReadSideInfo(&h, d.sideInfoBuf)
+	if err != nil {
+		return fmt.Errorf("failed to read side info: %w", err)
+	}
+
+	frameLen, err := h.GetFrameLength()
+	if err != nil {
+		return fmt.Errorf("failed to calculate frame length: %w", err)
+	}
+	crcLen := 0
+	if h.HasCRC() {
+		crcLen = 2
+	}
+
+	mainDataLen := frameLen - 4 - sideInfoLen - crcLen
+	if cap(d.cur) < mainDataLen {
+		d.cur = make([]byte, mainDataLen)
+	}
+	d.cur = d.cur[:mainDataLen]
+	if _, err := io.ReadFull(d.r, d.cur); err != nil {
+		return fmt.Errorf("failed to read main data: %w", err)
+	}
+	if err := maindata.ReadMainData(sideInfo.MainDataBegin, &d.mainDataReservoir, d.cur, &d.mainData); err != nil {
+		return fmt.Errorf("failed to read main data: %w", err)
+	}
+	br := common.NewBitReader(d.mainData)
+	frameChannels := 2
+	if h.GetChannelMode() == header.ChannelModeMono {
+		frameChannels = 1
+	}
+	if d.sampleRate == 0 {
+		d.sampleRate = h.GetSampleRate()
+		d.channels = frameChannels
+	} else if d.sampleRate != h.GetSampleRate() || d.channels != frameChannels {
+		return fmt.Errorf("variable stream parameters are not supported: sampleRate=%d/%d channels=%d/%d", d.sampleRate, h.GetSampleRate(), d.channels, frameChannels)
+	}
+
+	for gr := range GRANULE_COUNT {
+		for ch := 0; ch < frameChannels; ch++ {
+			gc := &sideInfo.Granule[gr][ch]
+			part23Start := br.Pos
+			part23End := part23Start + int(gc.Part23Length)
+
+			var prev *maindata.Scalefactors
+			if gr == 1 {
+				prev = &d.scalefactors[0][ch]
 			}
-			if frameChannels == 2 {
-				left := reorderedValues[gr][0][:]
-				right := reorderedValues[gr][1][:]
-				if err := stereo.ApplyJointStereo(h.GetSampleRate(), h.GetChannelMode(), h.GetModeExtension(), &sideInfo.Granule[gr][0], &scalefactors[gr][0], left, right, count1[gr][0], count1[gr][1]); err != nil {
-					return nil, 0, 0, fmt.Errorf("failed to apply joint stereo: frame granule=%d err=%w", gr, err)
-				}
+			_, err = maindata.ParseScaleFactor(br, gc, sideInfo.SCFSI[ch], gr, prev, &d.scalefactors[gr][ch])
+			if err != nil {
+				return fmt.Errorf("failed to parse scalefactors: frame granule=%d channel=%d err=%w", gr, ch, err)
 			}
-			for ch := 0; ch < frameChannels; ch++ {
-				hybridBuffer := hybridValues[gr][ch][:]
-				copy(hybridBuffer, reorderedValues[gr][ch][:])
-				if err := hybrid.ApplyAliasReduction(&sideInfo.Granule[gr][ch], hybridBuffer); err != nil {
-					return nil, 0, 0, fmt.Errorf("failed to apply alias reduction: frame granule=%d channel=%d err=%w", gr, ch, err)
-				}
-				if err := hybrid.HybridSynthesis(&sideInfo.Granule[gr][ch], hybridBuffer, &overlapState[ch], &hybridSamples[gr][ch]); err != nil {
-					return nil, 0, 0, fmt.Errorf("failed to run hybrid synthesis: frame granule=%d channel=%d err=%w", gr, ch, err)
-				}
-				synthesis.ApplyFrequencyInversion(&hybridSamples[gr][ch])
-				if err := synthesis.SynthesizeGranule(&hybridSamples[gr][ch], &synthesisState[ch], &pcmSamples[gr][ch]); err != nil {
-					return nil, 0, 0, fmt.Errorf("failed to run polyphase synthesis: frame granule=%d channel=%d err=%w", gr, ch, err)
-				}
+
+			huffmanLen := part23End - br.Pos
+			if huffmanLen < 0 {
+				return fmt.Errorf("main data underrun: frame granule=%d channel=%d part23=%d bits consumed for scalefactors=%d", gr, ch, gc.Part23Length, br.Pos-part23Start)
 			}
-			if frameChannels == 1 {
-				for i := 0; i < 576; i++ {
-					out = append(out, synthesis.QuantizeSample(pcmSamples[gr][0][i]))
-				}
-			} else {
-				for i := 0; i < 576; i++ {
-					out = append(out,
-						synthesis.QuantizeSample(pcmSamples[gr][0][i]),
-						synthesis.QuantizeSample(pcmSamples[gr][1][i]),
-					)
-				}
+			spectralBuffer := d.spectralValues[gr][ch][:]
+			_, err = maindata.ParseBigValues(br, h.GetSampleRate(), gc, part23End, &spectralBuffer)
+			if err != nil {
+				return fmt.Errorf("failed to parse big values: frame granule=%d channel=%d err=%w", gr, ch, err)
+			}
+			count1Lines, err := maindata.ParseCount1Values(br, gc, part23End, &spectralBuffer)
+			if err != nil {
+				return fmt.Errorf("failed to parse count1 values: frame granule=%d channel=%d err=%w", gr, ch, err)
+			}
+			d.count1[gr][ch] = int(gc.BigValues)*2 + count1Lines
+			requantizedBuffer := d.requantizedValues[gr][ch][:]
+			if err := maindata.Requantize(h.GetSampleRate(), gc, &d.scalefactors[gr][ch], spectralBuffer, &requantizedBuffer); err != nil {
+				return fmt.Errorf("failed to requantize values: frame granule=%d channel=%d err=%w", gr, ch, err)
+			}
+			reorderedBuffer := d.reorderedValues[gr][ch][:]
+			if err := maindata.Reorder(h.GetSampleRate(), gc, requantizedBuffer, &reorderedBuffer); err != nil {
+				return fmt.Errorf("failed to reorder values: frame granule=%d channel=%d err=%w", gr, ch, err)
+			}
+			br.Pos = part23End
+			if br.Pos > len(d.mainData)*8 {
+				return fmt.Errorf("main data overrun: frame granule=%d channel=%d part23=%d", gr, ch, gc.Part23Length)
+			}
+		}
+		if frameChannels == 2 {
+			left := d.reorderedValues[gr][0][:]
+			right := d.reorderedValues[gr][1][:]
+			if err := stereo.ApplyJointStereo(h.GetSampleRate(), h.GetChannelMode(), h.GetModeExtension(), &sideInfo.Granule[gr][0], &d.scalefactors[gr][0], left, right, d.count1[gr][0], d.count1[gr][1]); err != nil {
+				return fmt.Errorf("failed to apply joint stereo: frame granule=%d err=%w", gr, err)
+			}
+		}
+		for ch := 0; ch < frameChannels; ch++ {
+			hybridBuffer := d.hybridValues[gr][ch][:]
+			copy(hybridBuffer, d.reorderedValues[gr][ch][:])
+			if err := hybrid.ApplyAliasReduction(&sideInfo.Granule[gr][ch], hybridBuffer); err != nil {
+				return fmt.Errorf("failed to apply alias reduction: frame granule=%d channel=%d err=%w", gr, ch, err)
+			}
+			if err := hybrid.HybridSynthesis(&sideInfo.Granule[gr][ch], hybridBuffer, &d.overlapState[ch], &d.hybridSamples[gr][ch]); err != nil {
+				return fmt.Errorf("failed to run hybrid synthesis: frame granule=%d channel=%d err=%w", gr, ch, err)
+			}
+			synthesis.ApplyFrequencyInversion(&d.hybridSamples[gr][ch])
+			if err := synthesis.SynthesizeGranule(&d.hybridSamples[gr][ch], &d.synthesisState[ch], &d.pcmSamples[gr][ch]); err != nil {
+				return fmt.Errorf("failed to run polyphase synthesis: frame granule=%d channel=%d err=%w", gr, ch, err)
+			}
+		}
+		if frameChannels == 1 {
+			for i := 0; i < 576; i++ {
+				d.pcm = appendInt16LE(d.pcm, synthesis.QuantizeSample(d.pcmSamples[gr][0][i]))
+			}
+		} else {
+			for i := 0; i < 576; i++ {
+				d.pcm = appendInt16LE(d.pcm, synthesis.QuantizeSample(d.pcmSamples[gr][0][i]))
+				d.pcm = appendInt16LE(d.pcm, synthesis.QuantizeSample(d.pcmSamples[gr][1][i]))
 			}
 		}
 	}
 
-	return out, sampleRate, channels, nil
+	return nil
+}
+
+func appendInt16LE(dst []byte, sample int16) []byte {
+	u := uint16(sample)
+	return append(dst, byte(u), byte(u>>8))
 }


### PR DESCRIPTION
close #7 

External API now has io.Read-compatible API. This aims for migrating from hoshihajime/go-mp3. Regarding the benchmark, total allocation byte per operation has been reduced significantly because there's no longer a slice for the whole PCM at once.